### PR TITLE
Tabs/Generator: Changed blank from lambda to proc to avoid argument issu...

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,15 @@ Yhe I18n'ed title can be overriden passing the `:title` option to the
 = tabs_for @foos, flavor: (:tabs|:pills|:stacked), counters: (true|false) do |foos|
   - blank do
     .warning Nothing found
-  - tab "Tab label", "tab_div_id", foos.scope do
+  - tab "Tab label", "tab_div_id", foos.scope, present: (false|true)  do
     = render(partial: 'foos', locals: { foos: foos.scope })
 ```
+When a tab scope is empty, Stradivari will by default not show the tab. You can force the tab to show
+with the ```present: true``` option.
 
+The blank block is rendered in two cases. The first, if the tabs_for scope is empty and there are no
+tabs with option ```present: true```. The second, if a tab has this option, but its personal scope is
+empty.
 
 ### Filter
 

--- a/lib/stradivari/tabs/generator.rb
+++ b/lib/stradivari/tabs/generator.rb
@@ -7,7 +7,7 @@ module Stradivari
           super(parent, opts)
 
           @label    = label
-          @dom_id   = dom_id
+          @dom_id   = self.class.css_friendly(dom_id)
           @content  = content
           @renderer = renderer
         end
@@ -43,6 +43,12 @@ module Stradivari
             view.instance_exec(@content, &renderer)
           end
         end
+
+        # If the dom_id has css selector characters in them, it will muck up any search,
+        # so this method converts the dom_id to a less dangerous form.
+        def self.css_friendly dom_id
+          dom_id.gsub( /[\[\]:.]/, '_' )
+        end
       end
 
       def initialize(view, *pass, &definition)
@@ -65,7 +71,7 @@ module Stradivari
 
       def to_s
         tabs = @tabs.reject(&:blank?)
-        blank = @blank || lambda { }
+        blank = @blank || Proc.new { }
 
         renderer = if tabs.blank?
           blank


### PR DESCRIPTION
...es. Any CSS selector characters in the dom_id will now be replaced with '_' so jQuery (at the heart of the bootstrap nav js) will locate the tab panes correctly