### PR TITLE
Added no_data block to tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ set on the row element. A good use case for this would be if you wanted
 to bind a click handler to the row and needed to record the `foo.id` for
 an action specific to that object.
 
+If there is no data, the table will be replaced with a div saying
+`There is no data.` You can change this in one of two ways - specify a
+different message as the no_data option:
+```haml
+= table_for @foos, no_data: 'There is nothing to see here'
+```
+or, provide a `no_data` block which will be rendered in place:
+```haml
+= table_for @foos do
+  - no_data do
+    There are no entries.
+    %a.btn.btn-default{ href:'#' } Create
+```
+
 ### CSV
 
 ```haml

--- a/lib/stradivari/table/generator.rb
+++ b/lib/stradivari/table/generator.rb
@@ -120,6 +120,10 @@ module Stradivari
         @row = block
       end
 
+      def no_data &block
+        @no_data = block
+      end
+
       def column(*args, &renderer)
         opts, attr = args.extract_options!, args.first
 
@@ -167,7 +171,11 @@ module Stradivari
         end
 
         def generate_no_data
-          haml_tag :div, @opts[:no_data], class: 'no-data alert alert-warning'
+          if @no_data
+            haml_tag :div, class: 'no-data alert alert-warning', &@no_data
+          else
+            haml_tag :div, @opts[:no_data], class: 'no-data alert alert-warning'
+          end
         end
 
         def render_header

--- a/lib/stradivari/version.rb
+++ b/lib/stradivari/version.rb
@@ -1,3 +1,3 @@
 module Stradivari
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
I found the need to add a "no_data" block to tables, so I can render a create button (for example). What do you think?

I also thought it was a good time to bump the minor-minor version number :)