### PR TITLE
Remove the creator attribute from generated XLSX documents

### DIFF
--- a/lib/stradivari/xlsx/generator.rb
+++ b/lib/stradivari/xlsx/generator.rb
@@ -41,7 +41,7 @@ module Stradivari
 
       protected
         def xlsx
-          Axlsx::Package.new do |package|
+          Axlsx::Package.new({ author: '' }) do |package|
             package.use_shared_strings = true
             # apply column styling if set
             package.workbook.add_worksheet(name: opts.fetch(:sheet, nil)) do |sheet|


### PR DESCRIPTION
The `axlsx` gem sets the creator attribute to 'axlsx' if not set. I've submitted https://github.com/randym/axlsx/pull/441 to remove the default, but until that's merged this explicitly sets it to an empty string.