### PR TITLE
BUG FIX - Skip filters that are represented by ['']

### DIFF
--- a/lib/stradivari/filter/model/active_record.rb
+++ b/lib/stradivari/filter/model/active_record.rb
@@ -50,7 +50,7 @@ module Stradivari
 
             # Process search scopes
             ransack_params = params.delete_if do |k, v|
-              if v.blank?
+              if Array(v).reject(&:blank?).blank?
                 true # Don't bother processing blank values
 
               elsif (scope = stradivari_scopes.fetch(k.to_sym, nil))


### PR DESCRIPTION
Hey guys, this workaround https://github.com/ifad/stradivari/blob/22ff91bcb39bff1a96265142f51984903716d111/lib/stradivari/table/generator.rb#L273-L284

Is making `['']`, been passed in the URL and that is been used as filter, since `[''].blank?` is false, and that is messing with the filters on the export.

If you guys have another approach I all ears to it.