### PR TITLE
Add options to include or not blank option and to have a default checked value

### DIFF
--- a/lib/stradivari/filter/builder/selection_field.rb
+++ b/lib/stradivari/filter/builder/selection_field.rb
@@ -21,6 +21,12 @@ module Stradivari
               if collection.kind_of?(Array) && collection.size <= radios_max
                 instance_exec(&Helpers.radios_for_collection(collection, attr, opts))
               else
+                options =  if opts[:include_blank].to_s.present? && opts[:include_blank].to_s == 'false'
+                  {selected: opts[:value]}
+                else
+                  {selected: opts[:value], include_blank: 'Any'}
+                end
+
                 haml_concat select(opts[:namespace], attr, collection, {selected: opts[:value], include_blank: 'Any'}, {class: 'form-control'})
               end
             end

--- a/lib/stradivari/filter/helpers.rb
+++ b/lib/stradivari/filter/helpers.rb
@@ -9,7 +9,7 @@ module Stradivari
 
 
             collection.each do |title, value|
-              checked = (opts[:value].to_s == value.to_s)
+              checked = (opts[:value].to_s == value.to_s || opts[:default_checked].to_s == value.to_s)
               any_checked = false if checked
 
               haml_tag :div, class: Helpers::prepare_radio_class(checked, 'radio') do
@@ -20,10 +20,12 @@ module Stradivari
               end
             end
 
-            haml_tag :div, class: Helpers::prepare_radio_class(any_checked, 'radio') do
-              haml_tag :label do
-                haml_concat radio_button(opts[:namespace], attr, '', checked: any_checked)
-                haml_concat 'Any'
+            if opts[:include_blank].blank? || (opts[:include_blank].present? && topts[:include_blank].to_s == 'true')
+              haml_tag :div, class: Helpers::prepare_radio_class(any_checked, 'radio') do
+                haml_tag :label do
+                  haml_concat radio_button(opts[:namespace], attr, '', checked: any_checked)
+                  haml_concat 'Any'
+                end
               end
             end
           end

--- a/lib/stradivari/version.rb
+++ b/lib/stradivari/version.rb
@@ -1,3 +1,3 @@
 module Stradivari
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
 - If the option `include_blank: false` is present, the `Any` options won't be rendered
 - Now we have the option `default_checked`, that it is used to render a the default one checked

This was implemented for https://github.com/ifad/kit/pull/286