### PR TITLE
Replace axlsx with caxlsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+* [FEATURE] Replace axlsx with caxlsx ([#25](https://github.com/ifad/stradivari/issues/25))
+
 ## 0.6.3
 
 * [BUGFIX] Fix blank option and default checked value ([#31](https://github.com/ifad/stradivari/issues/31))

--- a/lib/stradivari/version.rb
+++ b/lib/stradivari/version.rb
@@ -1,3 +1,3 @@
 module Stradivari
-  VERSION = "0.6.3"
+  VERSION = "0.7.0"
 end

--- a/lib/stradivari/xlsx/generator.rb
+++ b/lib/stradivari/xlsx/generator.rb
@@ -1,4 +1,4 @@
-require 'axlsx'
+require 'caxlsx'
 
 module Stradivari
   module XLSX

--- a/stradivari.gemspec
+++ b/stradivari.gemspec
@@ -34,5 +34,5 @@ This Gem combines HAML and Bootstrap 3 to provide you easy generators for:
   spec.add_runtime_dependency 'pg_search'
   spec.add_runtime_dependency 'ransack'
   spec.add_runtime_dependency 'haml'
-  spec.add_runtime_dependency 'axlsx'
+  spec.add_runtime_dependency 'caxlsx'
 end


### PR DESCRIPTION
Close #25

I've tested this change with both Numbers and Excel on an internal project, by comparing the uncompressed `.xlsx` file.

Please keep this still on hold

In any case:
- We should bump version to 0.7.x to make clear that the update _may_ break things
- We should add a heads-up in the release notes about this dependency change
- An internal project is already using version 3.x: if something was wrong, we would have known for sure
