### PR TITLE
Bugfix/fix radios for collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.3
+
+* [BUGFIX] Fix blank option and default checked value ([#31](https://github.com/ifad/stradivari/issues/31))
+
 ## 0.6.2
 
 * [FEATURE] Add options to specify blank option and default checked value ([#29](https://github.com/ifad/stradivari/pull/29))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.6.2
+
+* [FEATURE] Add options to specify blank option and default checked value ([#29](https://github.com/ifad/stradivari/pull/29))
+
+## 0.6.1
+
+* [ENHANCEMENT] PgSearch Fix deprecation warning ([#28](https://github.com/ifad/stradivari/pull/28))
+
+## 0.6.0
+
+* [FEATURE] Rails 6 Support ([#27](https://github.com/ifad/stradivari/pull/27))

--- a/lib/stradivari/filter/builder/selection_field.rb
+++ b/lib/stradivari/filter/builder/selection_field.rb
@@ -21,11 +21,8 @@ module Stradivari
               if collection.kind_of?(Array) && collection.size <= radios_max
                 instance_exec(&Helpers.radios_for_collection(collection, attr, opts))
               else
-                options =  if opts[:include_blank].to_s.present? && opts[:include_blank].to_s == 'false'
-                  {selected: opts[:value]}
-                else
-                  {selected: opts[:value], include_blank: 'Any'}
-                end
+                options = { selected: opts[:value] }
+                options[:include_blank] = 'Any' if opts.fetch(:include_blank, true).to_s == 'true'
 
                 haml_concat select(opts[:namespace], attr, collection, {selected: opts[:value], include_blank: 'Any'}, {class: 'form-control'})
               end

--- a/lib/stradivari/filter/helpers.rb
+++ b/lib/stradivari/filter/helpers.rb
@@ -20,7 +20,7 @@ module Stradivari
               end
             end
 
-            if opts[:include_blank].blank? || (opts[:include_blank].present? && topts[:include_blank].to_s == 'true')
+            if opts.fetch(:include_blank, true).to_s == 'true'
               haml_tag :div, class: Helpers::prepare_radio_class(any_checked, 'radio') do
                 haml_tag :label do
                   haml_concat radio_button(opts[:namespace], attr, '', checked: any_checked)

--- a/lib/stradivari/version.rb
+++ b/lib/stradivari/version.rb
@@ -1,3 +1,3 @@
 module Stradivari
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end


### PR DESCRIPTION
Fix a typo in radios for collection helper. Also, since `false.blank?` evaluates
to `true`, this commit fixes the wrong behavior when `include_blank` was set to
`false`.

This change still supports passing `"true"` and `"false"` as strings

Ref: d067b99

Fix: #31 